### PR TITLE
Set hidden API key as environment variable

### DIFF
--- a/.github/workflows/apikey.yml
+++ b/.github/workflows/apikey.yml
@@ -1,0 +1,5 @@
+steps:
+  - name: Get API Key
+    env:
+      API_KEY: ${{ secrets.api-key }}
+      


### PR DESCRIPTION
Obtain API key from GitHub Secrets and declare it as an environment variable to prevent exposed API key.