### PR TITLE
Have cloudbuild.yaml skip unit tests

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,6 +5,7 @@ steps:
         - 'clean'
         - 'package'
         - 'appengine:deploy'
+        - '-Dmaven.test.skip=true'
         - '-Dapp.deploy.promote=False'
         - '-Dapp.deploy.version=$_PR_NUMBER'
         - '-Dapp.deploy.projectId=$PROJECT_ID'


### PR DESCRIPTION
As GitHub presubmit workflow already runs the tests, it is redundant/confusing to have the deploy flow run them again.