### PR TITLE
Add size label action

### DIFF
--- a/.github/workflows/size-label.yml
+++ b/.github/workflows/size-label.yml
@@ -1,0 +1,12 @@
+name: size-label
+
+on: pull_request
+
+jobs:
+  size-label:
+    runs-on: ubuntu-latest
+    steps:
+    - name: size-label
+      uses: "pascalgn/size-label-action@ee2c1d869559066f4c5242f20c658e402e937e73"
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This allows PRs to be automatically labeled based on their size. This is done via the [Assign size label](https://github.com/marketplace/actions/assign-size-label) action.

<img width="424" alt="Screen Shot 2020-07-06 at 6 44 53 PM" src="https://user-images.githubusercontent.com/6922353/86660558-d6643300-bfb8-11ea-8cc8-3559a07724be.png">
