### PR TITLE
Add config for Stylelint

### DIFF
--- a/.github/linters/.stylelintrc.json
+++ b/.github/linters/.stylelintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": "stylelint-config-standard",
+  "rules": {
+    "number-leading-zero": "never"
+  }
+}


### PR DESCRIPTION
Add a config file for stylelint that corrects the number-leading-zero rule to be "never", as per Google's external style guide.