### PR TITLE
Comment out postAndGetTaskList

### DIFF
--- a/src/main/webapp/auth.js
+++ b/src/main/webapp/auth.js
@@ -60,7 +60,9 @@ function handleAuthenticationState() {
     populateGmail();
     populateTasks();
     populateCalendar();
-    postAndGetTaskList();
+    // TEMPORARY: Commenting this out since it adds tasks to user's
+    // Tasks account on every run.
+    // postAndGetTaskList();
 
     // Populate magic feature panels at the bottom of the dashboard
     populateGo();


### PR DESCRIPTION
Commenting the JavaScript function postAndGetTaskList out since it adds tasks to user's Tasks account on every run.